### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,11 @@
+name: Test Livermore Loops
+
+on:
+  workflow_dispatch: # run from webUI
+  schedule:
+    # run once a week at 4:05 Wed.
+    - cron: '5 4 * * 3'
+
+jobs:
+  Does_It_Build:
+    uses: sacbase/.github/.github/workflows/just_build.yml@f1e6400eeb1aaa5a67e109e1a893fae1772023fc

--- a/loop01/loop01.sac
+++ b/loop01/loop01.sac
@@ -58,7 +58,7 @@ double[.] Loop1_TC1( int nolir, int n, double q, double r, double t,
 {
   return with {
            ( [0] <= [k] < [n]) : q + y[k] * (r*z[k+10] + t*z[k+11]);
-         } : genarray( [1001], tod(nolir));
+         } : genarray( [SIZE], tod(nolir));
 }
 
 double[.] Loop1_TC2( int nolir, int n, double q, double r, double t,


### PR DESCRIPTION
With this we have a scheduled build of the project with a reasonably recent version of the compiler... the trick is to use a *reusable workflow*, which is defined at https://github.com/SacBase/.github.